### PR TITLE
[CI-134] Add support for customizing Bamboo Agent config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,11 @@ RUN mkdir -p /var/run/sshd
 # Bamboo build agent requirements
 ENV BAMBOO_AGENT_INSTALLER /opt/bamboo-agent.jar
 ENV BAMBOO_AGENT_HOME /root/bamboo-agent-home
-ENV BAMBOO_CAPABILITIES_FILE bin/bamboo-capabilities.properties
+ENV BAMBOO_CAPABILITIES_FILE=$BAMBOO_AGENT_HOME/bin/bamboo-capabilities.properties
+ADD bamboo/bamboo-capabilities.properties $BAMBOO_CAPABILITIES_FILE
+ENV BAMBOO_CONFIG_FILE $BAMBOO_AGENT_HOME/bamboo-agent.cfg.xml
+ADD bamboo/bamboo-agent.cfg.xml $BAMBOO_CONFIG_FILE
 # Ubuntu 14.04 does not have openjdk-8 by default
-ADD bamboo/bamboo-capabilities.properties $BAMBOO_AGENT_HOME/$BAMBOO_CAPABILITIES_FILE
 RUN apt-get install -y --no-install-recommends software-properties-common \
   && add-apt-repository ppa:openjdk-r/ppa \
   && apt-get update -qq \

--- a/bamboo/bamboo-agent.cfg.xml
+++ b/bamboo/bamboo-agent.cfg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configuration>
+  <agentDefinition>
+    <name></name>
+    <description></description>
+  </agentDefinition>
+</configuration>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,18 +18,48 @@ elif [ "$BAMBOO_AUTOSTART" = '1' ]; then
     exit 1
   fi
 
+  # Customize config
+  if [ -n "$BAMBOO_NAME" ] && [ -n "$HOSTNAME" ]; then
+    sed -i "s/<name><\/name>/<name>$BAMBOO_NAME ($HOSTNAME)<\/name>/g" $BAMBOO_CONFIG_FILE
+    sed -i "s/<description><\/description>/<description>Bamboo Build Agent $BAMBOO_NAME, Docker Container $HOSTNAME<\/description>/g" $BAMBOO_CONFIG_FILE
+  else
+    rm $BAMBOO_CONFIG_FILE
+  fi
+
+  # SSH
+  if [ -d '/root/.ssh/' ]; then
+    # Fix possibly incorrect permissions
+    chown -R root:root '/root/.ssh/'
+    chmod 755 '/root/.ssh/'
+    chmod 644 '/root/.ssh/id_rsa.pub' || /bin/true
+    chmod 600 '/root/.ssh/id_rsa'     || /bin/true
+
+    # Capability 'ssh.bamboo'?
+    grep 'SHA256:odzbpWP/ro7DyfomL5s+/YjQDvvJfaEh+gEnb701ZTI' <( ssh-keygen -lf '/root/.ssh/id_rsa.pub' ) > /dev/null 2>&1
+    if [ "$?" == "0" ]; then
+      # Check keypair
+      diff <( ssh-keygen -y -e -f '/root/.ssh/id_rsa' ) <( ssh-keygen -y -e -f '/root/.ssh/id_rsa.pub' ) > /dev/null 2>&1
+      if [ "$?" == "0" ]; then
+        BAMBOO_CAPABILITIES="$BAMBOO_CAPABILITIES;ssh.bamboo=true"
+      fi
+    fi
+  fi
+
   # Add addional capabilties if env var is set
   if [ -n "$BAMBOO_CAPABILITIES" ]; then
     OIFS=$IFS
     IFS=';'
     for i in $BAMBOO_CAPABILITIES; do
-      echo $i >> $BAMBOO_AGENT_HOME/$BAMBOO_CAPABILITIES_FILE
+      echo $i >> $BAMBOO_CAPABILITIES_FILE
     done
     IFS=$OIFS
   fi
 
+  # Remove possible blank lines
+  sed -i '/^\s*$/d' $BAMBOO_CAPABILITIES_FILE
+
   if [ -z "$BAMBOO_AGENT_INSTALLER_URL" ]; then
-    echo "No BAMBOO_AGENT_INSTALLER_URL provided. Format ex.: http://bamboo.example.com/agentServer/agentInstaller/atlassian-bamboo-agent-installer-5.10.1.1.jar. Exiting..."
+    echo "No BAMBOO_AGENT_INSTALLER_URL provided. Format ex.: http://bamboo.example.com/agentServer/agentInstaller/atlassian-bamboo-agent-installer-latest.jar. Exiting..."
     exit 1
   fi
 


### PR DESCRIPTION
* Make sure the latest Agent version is downloaded
* ENV var 'PREFIX' can be used to set Bamboo Agent name to "$PREFIX-$HOSTNAME"
* Bamboo Agent capability 'ssh.bamboo' set automatically if correct privatekey