### PR TITLE
[CI-195] Bamboo Agent Cleanup: Overhaul script

### DIFF
--- a/bamboo/clearAgentSpace.sh
+++ b/bamboo/clearAgentSpace.sh
@@ -10,10 +10,6 @@ agentLocation="${BAMBOO_AGENT_HOME}"
 bambooUrl="${BAMBOO_SERVER_URL}"
 uuid="${BAMBOO_API_TOKEN}"
 
-# Make temp directory
-TMPFILE=`mktemp -d /tmp/clearAgentSpace.XXXXXX` || exit 1
-find ${TMPFILE} -type d -exec chmod 0755 {} \;
-
 # To extract property value from JSON response
 # https://gist.github.com/cjus/1047794
 function jsonValue() {
@@ -22,8 +18,8 @@ function jsonValue() {
 	awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/'$KEY'\042/){print $(i+1)}}}' | tr -d '"' | sed -n ${num}p
 }
 
-#check for required libraries/tools and setup tempdir
-command -v curl >/dev/null 2>&1 || { echo "$(date): Required tool 'curl' not found" | tee -a $TMPFILE/log.txt ;exit 2; }
+#check for required libraries/tools
+command -v curl >/dev/null 2>&1 || { echo "$(date): Required tool 'curl' not found"; exit 2; }
 
 # Run endlessly
 while [ true ]; do
@@ -31,88 +27,93 @@ while [ true ]; do
 	if [ -e "${agentLocation}/bamboo-agent.cfg.xml" ]; then
 		agentId=`cat ${agentLocation}/bamboo-agent.cfg.xml | grep -oPm1 "(?<=<id>)[^<]+"`
 		buildWorkingDir=`cat ${agentLocation}/bamboo-agent.cfg.xml | grep -oPm1 "(?<=<buildWorkingDirectory>)[^<]+"`
+		agentStatusPrevious="unknown"
 
-		# Already clean?
+		# Cleanup needed?
 		if [ -e "$buildWorkingDir" ]; then
+			echo "$(date): -= Bamboo Agent Cleanup =-"
+
 			# Check if both variables are not null
 			if [ -z ${agentId} ] || [ -z ${buildWorkingDir} ] || [ -z ${uuid} ]; then
-				echo "$(date): agentId or buildWorkingDir or uuid not found" | tee -a $TMPFILE/log.txt
+				echo "$(date): agentId or buildWorkingDir or uuid not found"
 			else
-				echo "$(date): Agent ID ${agentId}" | tee -a $TMPFILE/log.txt
-				echo "$(date): Artifacts location ${buildWorkingDir}" | tee -a $TMPFILE/log.txt
-				echo "$(date): Token ${uuid}" | tee -a $TMPFILE/log.txt
-				echo "$(date): Running Disk Purge for Agent $agentId" | tee -a $TMPFILE/log.txt
+				echo "$(date): Agent ID ${agentId}"
+				echo "$(date): BuildDir ${buildWorkingDir}"
+				echo "$(date): API Token ${uuid}"
 
-				# disable agent
-				echo "" | tee -a $TMPFILE/log.txt
-				echo "$(date) Disabling the agent and checking status" | tee -a $TMPFILE/log.txt
-				curl -s -k -c $TMPFILE/cookies "$bambooUrl" 2>&1 | tee -a $TMPFILE/log.txt
-				curl -s -X POST -k -b $TMPFILE/cookies -H "Content-Type: application/json" "$bambooUrl/rest/agents/1.0/$agentId/state/disable?uuid=${uuid}" 2>&1 | tee -a $TMPFILE/log.txt
-
-				# Once the agent is disabled wait for about 2 minutes. Observed a latency between the agent starting to perform a job and the bamboo server
-				# realizing the agent is busy
-				echo "$(date): Sleeping for 120 seconds to give a chance for the bamboo server to get updated info. Messaging delay benifit of doubt" | tee -a $TMPFILE/log.txt
-				sleep 120
+				# Make temp directory
+				TMPDIR=`mktemp -d /tmp/clearAgentSpace.XXXXXX` || { echo "$(date): Failed creating TMPDIR"; continue; }
+				find ${TMPDIR} -type d -exec chmod 0755 {} \;
+				echo "$(date): TMPDIR '${TMPDIR}'"
 
 				# Check current agent status
-				echo "$(date): Proceeding with monitoring the status until agent is idle" | tee -a $TMPFILE/log.txt
-				curl -s -k -b $TMPFILE/cookies "$bambooUrl/rest/agents/1.0/$agentId/state?uuid=${uuid}" -o $TMPFILE/state.txt 2>&1 | tee -a $TMPFILE/log.txt
-				agentStatus=`cat $TMPFILE/state.txt | jsonValue enabled` 
-				busy=`cat $TMPFILE/state.txt | jsonValue busy` 
-				echo "$(date): Is the agent busy? $busy" | tee -a $TMPFILE/log.txt
-				echo "$(date): Is the agent enabled? $agentStatus" | tee -a $TMPFILE/log.txt
-				if [ "$busy" == "true" ]; then
-					echo "$(date): Agent is still running a job, waiting ..\n" | tee -a $TMPFILE/log.txt
-					# while polling, and is still running, sleep
-					running=1
-					while [ $running -eq 1 ]; do
-						sleep 10
-						curl -s -k -b $TMPFILE/cookies "$bambooUrl/rest/agents/1.0/$agentId/state?uuid=${uuid}" -o $TMPFILE/state.txt 2>&1 | tee -a $TMPFILE/log.txt
-						busy=`cat $TMPFILE/state.txt | jsonValue busy`
-						echo "$(date): Is the agent busy? $busy" | tee -a $TMPFILE/log.txt
-						if [ "$busy" == "false" ]; then
-							echo "$(date): Yay, it's idle now!\n" | tee -a $TMPFILE/log.txt
+				curl -s -c $TMPDIR/cookies "$bambooUrl" > /dev/null || { echo "$(date): Failed creating Cookie"; continue; }
+				curl -s -b $TMPDIR/cookies "$bambooUrl/rest/agents/1.0/$agentId/state?uuid=${uuid}" -o $TMPDIR/state.txt > /dev/nul || { echo "$(date): Failed getting Agent status"; continue; }
+				agentStatusEnabledPrevious=`cat $TMPDIR/state.txt | jsonValue enabled`
+
+				# Disable Agent?
+				if [ "$agentStatusEnabledPrevious" == "true" ]; then
+					echo "$(date): Disabling the agent and checking status"
+					while [ true ]; do
+						curl -s -X POST -b $TMPDIR/cookies -H "Content-Type: application/json" "$bambooUrl/rest/agents/1.0/$agentId/state/disable?uuid=${uuid}" > /dev/nul || { echo "$(date): Failed disabling Agent"; continue; }
+						curl -s -b $TMPDIR/cookies "$bambooUrl/rest/agents/1.0/$agentId/state?uuid=${uuid}" -o $TMPDIR/state.txt > /dev/nul
+						agentStatus=`cat $TMPDIR/state.txt | jsonValue enabled`
+						if [ "$agentStatus" == "false" ]; then
 							break
-						else
-							echo "$(date): still busy..\n" | tee -a $TMPFILE/log.txt
 						fi
+						sleep 10
+					done
+				else
+					echo "$(date): Agent already disabled"
+				fi
+
+				# Wait until Agent is idle
+				echo "$(date): Waiting for Agent to become idle (>= 120 sec) ..."
+				# Countermeasure: Sleeping at least 120 secs to make sure Bamboo has current busy status when Agent just fetched a new job
+				sleep 120
+				while [ true ]; do
+					curl -s -b $TMPDIR/cookies "$bambooUrl/rest/agents/1.0/$agentId/state?uuid=${uuid}" -o $TMPDIR/state.txt > /dev/nul || { echo "$(date): Failed getting Agent status"; continue; }
+					busy=`cat $TMPDIR/state.txt | jsonValue busy`
+					if [ "$busy" == "false" ]; then
+						break
+					fi
+					sleep 10
+				done
+
+				# CLEANUP
+				echo "$(date): Agent is disabled and idle, starting cleanup"
+
+				echo "$(date): * Workdir ${buildWorkingDir}"
+				rm -rf ${buildWorkingDir}
+
+				echo "$(date): * Docker containers, images, volumes"
+				docker ps -a -q | xargs -r docker rm -f -v
+				docker images -q | xargs -r docker rmi -f
+				docker volume ls -q | xargs -r docker volume rm
+				docker volume ls -q -f dangling=true | xargs -r docker volume rm
+
+				echo "$(date): Disk clear activities complete"
+
+				# Re-enable agent?
+				if [ "${agentStatusEnabledPrevious}" == "true" ]; then
+					echo "$(date): Re-enabling the agent"
+					while [ true ]; do
+						curl -s -X POST -b $TMPDIR/cookies -H "Content-Type: application/json" "$bambooUrl/rest/agents/1.0/$agentId/state/enable?uuid=${uuid}" > /dev/nul || { echo "$(date): Failed enabling Agent"; continue; }
+						curl -s -b $TMPDIR/cookies "$bambooUrl/rest/agents/1.0/$agentId/state?uuid=${uuid}" -o $TMPDIR/state.txt > /dev/nul
+						agentStatus=`cat $TMPDIR/state.txt | jsonValue enabled`
+						if [ "$agentStatus" == "true" ]; then
+							break
+						fi
+						sleep 10
 					done
 				fi
 
-				echo "$(date): Agent is disabled and idle, starting cleanup" | tee -a $TMPFILE/log.txt
-
-				echo "* Workdir ${buildWorkingDir}" | tee -a $TMPFILE/log.txt
-				rm -rf ${buildWorkingDir} | tee -a $TMPFILE/log.txt
-
-				echo "* Docker volumes, containers, images" | tee -a $TMPFILE/log.txt
-				docker kill $(docker ps -q) | tee -a $TMPFILE/log.txt
-				docker volume rm $(docker volume ls -q) | tee -a $TMPFILE/log.txt
-				docker rm -f -v $(docker ps -a) | tee -a $TMPFILE/log.txt
-				docker rmi -f $(docker images -q) | tee -a $TMPFILE/log.txt
-
-				echo "$(date): Disk clear activities complete." | tee -a $TMPFILE/log.txt
-				echo "$(date): Disk Info\n" | tee -a $TMPFILE/log.txt
-				df -h | sed -e 's/^/\'$'\t/g' | tee -a $TMPFILE/log.txt
-
-				# Re-enable agent after the clearn
-				echo "" | tee -a $TMPFILE/log.txt
-				echo "$(date): re-enabling the agent" | tee -a $TMPFILE/log.txt
-				curl -s -X POST -k -b $TMPFILE/cookies -H "Content-Type: application/json" "$bambooUrl/rest/agents/1.0/$agentId/state/enable?uuid=${uuid}" 2>&1 | tee -a $TMPFILE/log.txt
-
-				# Check current agent status
-				curl -s -k -b $TMPFILE/cookies "$bambooUrl/rest/agents/1.0/$agentId/state?uuid=${uuid}" -o $TMPFILE/state.txt 2>&1 | tee -a $TMPFILE/log.txt
-				agentStatus=`cat $TMPFILE/state.txt | jsonValue enabled` 
-				busy=`cat $TMPFILE/state.txt | jsonValue busy` 
-				echo "$(date): Is the agent enabled? $agentStatus" | tee -a $TMPFILE/log.txt
-				echo "" | tee -a $TMPFILE/log.txt
-				echo "$(date): Complete" | tee -a $TMPFILE/log.txt
-
+				rm -rf $TMPDIR
+				echo "$(date): FINISHED!"
 			fi
-		else
-			echo "$(date): Sleeping 1hr ..." | tee -a $TMPFILE/log.txt
-			sleep 3600
 		fi
 	else
-		echo "$(date): Agent configuration information not found at ${agentLocation}/bamboo-agent.cfg.xml" | tee -a $TMPFILE/log.txt 
+		echo "$(date): Agent configuration information not (yet) found at ${agentLocation}/bamboo-agent.cfg.xml"
 	fi
+	sleep 1
 done

--- a/etc/sv/bamboo_cleanup/run
+++ b/etc/sv/bamboo_cleanup/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec $BAMBOO_AGENT_HOME/clearAgentSpace.sh 2>&1
+exec $BAMBOO_AGENT_HOME/clearAgentSpace.sh >> /var/log/bamboo_cleanup.log 2>&1


### PR DESCRIPTION
* Hopefully fix race-condition
* Don't enable a previously disabled Agent
* Retry-loops for Agent <-> Bamboo API calls
* Log to /var/log/bamboo_cleanup.log
* Remove tempdir when finished
* Use xargs for docker cleanup cmds to properly handle noop
* Rework log messages