### PR TITLE
[CI-334] Remove docker pidfile to make sure it can start

### DIFF
--- a/etc/sv/docker/run
+++ b/etc/sv/docker/run
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+# Ensure we can (re)start
+rm -f /var/run/docker.pid
+
 exec /usr/local/bin/dind docker daemon --raw-logs -H 0.0.0.0:2375 -H unix:///var/run/docker.sock $DOCKER_DAEMON_ARGS >> /var/log/docker.log 2>&1


### PR DESCRIPTION
* Docker doesn't start if there is an existing pidfile (e.g. from a crashed docker)