### PR TITLE
[CI-342] add ubuntu version number to FROM line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ocedo/baseimage-docker:latest
+FROM quay.io/ocedo/baseimage-docker:14.04
 MAINTAINER Jan Zenkner <jan.zenkner@riverbed.com>
 
 # Stops apt-get from complaining about automated installation of packages


### PR DESCRIPTION
as we currently build 12.04, 14.04 and 16.04 base image versions and
push them to the same docker repo we should clarify which ubuntu
version DIND-builder wants to use